### PR TITLE
Fix outdated node.js warnings

### DIFF
--- a/.github/workflows/buildwheels.yml
+++ b/.github/workflows/buildwheels.yml
@@ -85,7 +85,7 @@ jobs:
           pip wheel ./dist/dune-common* -w output
           auditwheel repair output/dune_common*.whl -w output
         shell: bash  
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
 

--- a/.github/workflows/buildwheels.yml
+++ b/.github/workflows/buildwheels.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: starting
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: clone dune branch ${{ env.BRANCH }} and build python packages
         run: |
           set +e

--- a/.github/workflows/buildwheels.yml
+++ b/.github/workflows/buildwheels.yml
@@ -101,7 +101,7 @@ jobs:
         if: github.event.inputs.upload != ''
         run: echo "UPLOAD=${{ github.event.inputs.upload }}" >> $GITHUB_ENV
       - name: download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         continue-on-error: true
         with:
           name: packages

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -80,7 +80,7 @@ jobs:
           pip3 install scikit-build
           ./clone-modules $BRANCH $FEMBRANCH $UPLOAD $DOWNLOAD
       - name: upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: packages
           path: dist

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -73,7 +73,7 @@ jobs:
         if: github.event.inputs.upload != ''
         run: echo "UPLOAD=${{ github.event.inputs.upload }}" >> $GITHUB_ENV
       - name: starting
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: clone dune branch ${{ env.BRANCH }} and build python packages
         run: |
           set +e
@@ -105,7 +105,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: starting
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: environmentCore
         if: github.event.inputs.branch != ''
         run: echo "BRANCH=${{ github.event.inputs.branch }}" >> $GITHUB_ENV

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -147,7 +147,7 @@ jobs:
         shell: bash
       - name: download artifacts
         if: ${{ matrix.python == '3.10.6' || matrix.os == 'ubuntu-latest' }}
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         # if all packages exist on pypi then no artifacts are uploaded so don't fail
         continue-on-error: true
         with:
@@ -220,7 +220,7 @@ jobs:
         if: github.event.inputs.upload != ''
         run: echo "UPLOAD=${{ github.event.inputs.upload }}" >> $GITHUB_ENV
       - name: download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         continue-on-error: true
         with:
           name: packages

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -89,7 +89,7 @@ jobs:
           pip install scikit-build
           ./clone-modules $BRANCH $FEMBRANCH "none"
       - name: upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: packages
           path: dist/

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -52,7 +52,7 @@ jobs:
         echo "Using dune-core branch: ${{ github.event.inputs.branch }}"
         echo "Using dune-fem  branch: ${{ github.event.inputs.fembranch }}"
     - name: checkout source code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
     - id: setmatrix
       run: |
         matrixArray=$(find ./testing -name '*.sh') # Creates array of all files .sh withing testing
@@ -83,7 +83,7 @@ jobs:
         if: github.event.inputs.fembranch != ''
         run: echo "FEMBRANCH=${{ github.event.inputs.fembranch }}" >> $GITHUB_ENV
       - name: starting
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: clone dune branch ${{ env.BRANCH }} and build python packages
         run: |
           pip install scikit-build
@@ -110,7 +110,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: starting
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: environment
         if: github.event.inputs.logLevel != ''
         run: echo "LOGLEVEL=${{ github.event.inputs.logLevel }}" >> $GITHUB_ENV

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -149,7 +149,7 @@ jobs:
           fi
         shell: bash
       - name: download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         # if all packages exist on pypi then no artifacts are uploaded so don't fail
         continue-on-error: true
         with:


### PR DESCRIPTION
Update actions checkout, upload-artifact, download-artifact to version 4. The latter two are based on an outdated node.js version