### PR TITLE
[bugfix][mmesh] Disable test on Mac OS because of CGAL not compiling.

### DIFF
--- a/testing/mmeshFromSource.sh
+++ b/testing/mmeshFromSource.sh
@@ -1,3 +1,10 @@
+# do not run on macOS, currently failing because of CGAL
+if [ "$3" == "macOS" ]; then
+  echo "$0 disabled on Mac OS"
+  exit 0
+fi
+
+
 base="https://gitlab.dune-project.org"
 coreurl="$base/core"
 femurl="$base/dune-fem"


### PR DESCRIPTION
Enable again once fixed.