### PR TITLE
Revert "[bugfix][mmesh] Disable test on Mac OS because of CGAL not compiling."

### DIFF
--- a/testing/mmeshFromSource.sh
+++ b/testing/mmeshFromSource.sh
@@ -1,10 +1,3 @@
-# do not run on macOS, currently failing because of CGAL
-if [ "$3" == "macOS" ]; then
-  echo "$0 disabled on Mac OS"
-  exit 0
-fi
-
-
 base="https://gitlab.dune-project.org"
 coreurl="$base/core"
 femurl="$base/dune-fem"


### PR DESCRIPTION
Reverts dune-project/dune-testpypi#20. 

This should be merged once the problem with CGAL on Mac OS has been fixed or vanished.