### PR TITLE
reactivate failing tests on macos 

### DIFF
--- a/testing/completeSourceInEnv.sh
+++ b/testing/completeSourceInEnv.sh
@@ -1,8 +1,3 @@
-# do not run on macOS
-if [ "$3" == "macOS" ]; then
-  exit 0
-fi
-
 # setup an external venv
 python3 -m venv dune-env
 . dune-env/bin/activate

--- a/testing/installPlusSource.sh
+++ b/testing/installPlusSource.sh
@@ -1,9 +1,3 @@
-# do not run on macOS
-if [ "$3" == "macOS" ]; then
-  exit 0
-fi
-
-
 base="https://gitlab.dune-project.org"
 coreurl="$base/core"
 femurl="$base/dune-fem"


### PR DESCRIPTION
those were due to new handling of namespace packages in python and also the new versioning with the versions on pypi > dev versions produced by dunepackaging